### PR TITLE
Require Send for Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ impl<T: 'static> StaticSlot<T> {
 }
 
 unsafe impl<T: Send> Send for StaticSlot<T> {}
-unsafe impl<T: Sync> Sync for StaticSlot<T> {}
+unsafe impl<T: Sync + Send> Sync for StaticSlot<T> {}
 
 
 #[cfg(test)]


### PR DESCRIPTION
`swap` and `drop` methods allow to efectively trasfer a `T` from one
thread to another via `&StaticSlot<T>`, which means that we need `T:
Send` for `StaticSlot<T>` to be `Sync`.